### PR TITLE
Fix demo image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Also support youtube and mp4 video urls. It is leazy loading and heigly optimize
 
 <div align="center">
   
-  ![rm-image-slider Demo](https://github.com/malikrajat/rm-image-slider/assets/rm-image-slider-demo.giff)
+  ![rm-image-slider Demo](https://github.com/malikrajat/rm-image-slider/blob/main/assets/rm-image-slider-demo.gif)
   
   *Experience the power: Image carousel, lightbox popup, video support, and touch gestures - all in one lightweight component!*
 


### PR DESCRIPTION
Updated the demo image URL in the README to point to the correct .gif file in the repository. This ensures the demo image displays properly.